### PR TITLE
Fix retain cycle + renamed and moved completion handler

### DIFF
--- a/Loaf/Loaf/Loaf.swift
+++ b/Loaf/Loaf/Loaf.swift
@@ -169,12 +169,11 @@ final fileprivate class LoafManager: LoafDelegate {
     }
     
     fileprivate func presentIfPossible() {
-        if isPresenting == false, let loaf = queue.dequeue(), let sender = loaf.sender {
-            isPresenting = true
-            let loafVC = LoafViewController(loaf)
-            loafVC.delegate = self
-            sender.presentToast(loafVC)
-        }
+        guard isPresenting == false, let loaf = queue.dequeue(), let sender = loaf.sender else { return }
+        isPresenting = true
+        let loafVC = LoafViewController(loaf)
+        loafVC.delegate = self
+        sender.presentToast(loafVC)
     }
 }
 

--- a/LoafExamples/LoafExamples/Examples.swift
+++ b/LoafExamples/LoafExamples/Examples.swift
@@ -82,10 +82,9 @@ class Examples: UITableViewController {
             Loaf(example.rawValue, state: .info, sender: self).show()
             
         case .bottom:
-            Loaf(example.rawValue, sender: self).show()
-            Loaf("Loaf message", sender: self, completionHandler: {
-                print("Dismissal complete")
-            }).show()
+            Loaf(example.rawValue, sender: self).show {
+                print("Dismissed!")
+            }
         case .top:
             Loaf(example.rawValue, location: .top, sender: self).show()
             


### PR DESCRIPTION
Resolves https://github.com/schmidyy/Loaf/issues/1

Fixes retain cycle in sender
Renames `completionHandler` to `onTap`, and move call to `show()`

cc @RollingGoron