### PR TITLE
add dismiss method

### DIFF
--- a/Loaf/Loaf/Loaf.swift
+++ b/Loaf/Loaf/Loaf.swift
@@ -153,6 +153,18 @@ final public class Loaf {
         self.completionHandler = completionHandler
         LoafManager.shared.queueAndPresent(self)
     }
+    
+    /// Hide a loaf object manually
+    /// helpful if you need to present a view controller from the same view controller that is already
+    /// presenting a toast
+    /// - Parameter animated: should the dismissal be animated
+    public func dismiss(animated: Bool = true){
+        guard LoafManager.shared.isPresenting else { return }
+        guard let vc = sender?.presentedViewController as? LoafViewController else { return }
+        vc.dismiss(animated: animated) {
+            vc.delegate?.loafDidDismiss()
+        }
+    }
 }
 
 final fileprivate class LoafManager: LoafDelegate {


### PR DESCRIPTION
This PR adds a dismiss method to the Loaf object.

This is super beneficial for the following circumstance---
say you present a loaf and then while it is displaying, the user takes an action from within your main controller and you need to present a new view controller.

With the current code, this isn't possible because the main view controller is not allowed to present while the LoadViewController is being presented. And dismissing that view controller manually so that it can present, will cause the Loaf library issues since it will not reset its state via the isPresenting variable.

The solution is to retain your Loaf object while it is presenting and then if the main view controller must present, it may call currentLoaf.dismiss(animated: false) and then present its new view controller.
