### PR TITLE
Downgrade minimum required version to iOS 9 in Readme.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Don't forget to include `import Loaf` in every file you'd like to use Loaf
 ### Requirements
 
 - Swift 4.2+
-- iOS 11.0+
+- iOS 9.0+
 
 ### Contributing
 


### PR DESCRIPTION
Edited readme.md file to show the minimum required version merge in the previous pull request @schmidyy 