### PR TITLE
Replaced hardcoded container view insets

### DIFF
--- a/Sources/Loaf/Presenter/Controller.swift
+++ b/Sources/Loaf/Presenter/Controller.swift
@@ -32,18 +32,31 @@ final class Controller: UIPresentationController {
     
     override func presentationTransitionWillBegin() {
         guard let containerView = containerView else { return }
-        
+
+        var containerInsets: UIEdgeInsets
+        if #available(iOS 11, *) {
+            containerInsets = containerView.safeAreaInsets
+        } else {
+            let statusBarSize = UIApplication.shared.statusBarFrame.size
+            containerInsets = UIEdgeInsets(top: min(statusBarSize.width, statusBarSize.height), left: 0, bottom: 0, right: 0)
+        }
+
+        if let tabBar = loaf.sender?.parent as? UITabBarController{
+            containerInsets.bottom += tabBar.tabBar.frame.height
+        }
+
+        let prettyfierInset = CGFloat(10)
+        if containerInsets.bottom == 0 {
+            containerInsets.bottom += prettyfierInset
+        }
+        containerInsets.top += prettyfierInset
+
         let yPosition: CGFloat
         switch loaf.location {
         case .bottom:
-            let bottomMargin:CGFloat = containerView.frame.height - size.height
-            if let tabBar = loaf.sender?.parent as? UITabBarController{
-                yPosition = bottomMargin - 10 - tabBar.tabBar.frame.height
-            }else{
-                yPosition = bottomMargin - 40
-            }
+            yPosition = containerView.frame.origin.y + containerView.frame.height - size.height - containerInsets.bottom
         case .top:
-            yPosition = 50
+            yPosition = containerInsets.top
         }
         
         containerView.frame.origin = CGPoint(


### PR DESCRIPTION
Replaced hardcoded container view insets in Presenter/Controller with the safe area ones to fix appearance for devices like iPhone 7. Added proper margins for iOS pre-11 to take into account status bar, including rotation support and in-call status bar.