### PR TITLE
Add more customisation options

### DIFF
--- a/LoafExamples/LoafExamples/Base.lproj/Main.storyboard
+++ b/LoafExamples/LoafExamples/Base.lproj/Main.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="HGA-Nw-kVW">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="HGA-Nw-kVW">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,13 +14,13 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="5Xp-Wt-GOf">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <sections>
                             <tableViewSection headerTitle="Basic states" id="qDS-E9-w5O">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="4mw-3e-imJ" style="IBUITableViewCellStyleDefault" id="rw7-a0-AXj">
-                                        <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="38" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="rw7-a0-AXj" id="a8K-YQ-93C">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -39,7 +37,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="AHQ-P7-K0f" style="IBUITableViewCellStyleDefault" id="xjN-nq-Y6R">
-                                        <rect key="frame" x="0.0" y="99.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="81.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xjN-nq-Y6R" id="qOo-9M-LZZ">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -56,7 +54,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="DoX-UW-aSu" style="IBUITableViewCellStyleDefault" id="nrk-fq-pKO">
-                                        <rect key="frame" x="0.0" y="143.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="125" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nrk-fq-pKO" id="TC9-qv-8e0">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -73,7 +71,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="kQw-xt-Wz5" style="IBUITableViewCellStyleDefault" id="qp5-9s-VBt">
-                                        <rect key="frame" x="0.0" y="187.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="168.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qp5-9s-VBt" id="JYK-Oy-L8v">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -94,7 +92,7 @@
                             <tableViewSection headerTitle="Locations" id="LQC-uL-Kkp">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="Z05-fP-AZe" style="IBUITableViewCellStyleDefault" id="oXr-3O-t5e">
-                                        <rect key="frame" x="0.0" y="287.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="268" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oXr-3O-t5e" id="KHh-Ye-VHf">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -111,7 +109,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="7LP-Oj-mzN" style="IBUITableViewCellStyleDefault" id="PWU-94-I9y">
-                                        <rect key="frame" x="0.0" y="331.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="311.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PWU-94-I9y" id="Ma3-pi-mLq">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -132,7 +130,7 @@
                             <tableViewSection headerTitle="Directions" id="vmA-0H-jrO">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="Tc2-V5-oH4" style="IBUITableViewCellStyleDefault" id="wnH-N9-Kyf">
-                                        <rect key="frame" x="0.0" y="431.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="411" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wnH-N9-Kyf" id="oM6-rB-wO7">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -149,7 +147,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="Emn-N6-Zh8" style="IBUITableViewCellStyleDefault" id="wCh-S3-Kn3">
-                                        <rect key="frame" x="0.0" y="475.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="454.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="wCh-S3-Kn3" id="w4y-GS-uwp">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -166,7 +164,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="39N-VD-xkD" style="IBUITableViewCellStyleDefault" id="QNL-o1-UFg">
-                                        <rect key="frame" x="0.0" y="519.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="498" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="QNL-o1-UFg" id="Qj3-tG-3q0">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -183,7 +181,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="NiJ-JM-STj" style="IBUITableViewCellStyleDefault" id="44K-BE-SJL">
-                                        <rect key="frame" x="0.0" y="563.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="541.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="44K-BE-SJL" id="iAt-V7-sOO">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -204,7 +202,7 @@
                             <tableViewSection headerTitle="Custom" id="7LZ-wC-eKS">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="ag3-xj-QV9" style="IBUITableViewCellStyleDefault" id="1tn-TP-wy8">
-                                        <rect key="frame" x="0.0" y="663.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="641" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1tn-TP-wy8" id="hVP-NI-w1M">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -221,7 +219,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="H0I-Br-EDA" style="IBUITableViewCellStyleDefault" id="oQn-yv-Tdt">
-                                        <rect key="frame" x="0.0" y="707.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="684.5" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oQn-yv-Tdt" id="DNK-1Q-cIX">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -238,13 +236,30 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="kpy-eu-EL4" style="IBUITableViewCellStyleDefault" id="cfi-UN-gw3">
-                                        <rect key="frame" x="0.0" y="751.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="728" width="375" height="43.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cfi-UN-gw3" id="fCt-Pd-pad">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="No icon + custom width" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="kpy-eu-EL4">
+                                                    <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="K8Y-VQ-mUA" style="IBUITableViewCellStyleDefault" id="10c-rb-9cR">
+                                        <rect key="frame" x="0.0" y="771.5" width="375" height="43.5"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="10c-rb-9cR" id="1RF-LB-5BG">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Custom spacing/insets/icon size" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="K8Y-VQ-mUA">
                                                     <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -274,7 +289,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="HGA-Nw-kVW" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="KAA-CJ-Qp9">
-                        <rect key="frame" x="0.0" y="20" width="375" height="96"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="104.5"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </navigationBar>
@@ -288,4 +303,9 @@
             <point key="canvasLocation" x="1164" y="112.89355322338831"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/LoafExamples/LoafExamples/Examples.swift
+++ b/LoafExamples/LoafExamples/Examples.swift
@@ -116,7 +116,25 @@ class Examples: UITableViewController {
         case .custom4:
             let redColor = UIColor(red: 204.0/255, green: 51.0/255, blue: 51.0/255, alpha: 1)
             let lightRedColor = UIColor(red: 255.0/255, green: 238.0/255, blue: 238.0/255, alpha: 1)
-            Loaf(example.rawValue, state: .custom(.init(backgroundColor: lightRedColor, textColor: redColor, tintColor: redColor, icon: UIImage(named: "moon"), iconSize: CGSize(width: 16, height: 16), textAlignment: .left, iconAlignment: .right, width: .screenPercentage(0.8), spaceBetweenTextAndIcon: 16, contentInsets: UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16))), sender: self).show()
+            Loaf(
+                example.rawValue,
+                state: .custom(
+                    .init(
+                        backgroundColor: lightRedColor,
+                        textColor: redColor,
+                        tintColor: redColor,
+                        icon: UIImage(named: "moon"),
+                        iconSize: CGSize(width: 16, height: 16),
+                        textAlignment: .left,
+                        iconAlignment: .right,
+                        width: .screenPercentage(0.8),
+                        spaceBetweenTextAndIcon: 16,
+                        contentInsets: UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16),
+                        lineSpacing: 10.0
+                    )
+                ),
+                sender: self
+            ).show()
         }
         
         tableView.deselectRow(at: indexPath, animated: true)

--- a/LoafExamples/LoafExamples/Examples.swift
+++ b/LoafExamples/LoafExamples/Examples.swift
@@ -12,7 +12,7 @@ import Loaf
 class Examples: UITableViewController {
     
     private enum Example: String, CaseIterable {
-        case success  = "An action was successfully completed - An action was successfully completed"
+        case success  = "An action was successfully completed"
         case error    = "An error has occured"
         case warning  = "A warning has occured"
         case info     = "This is some information"

--- a/LoafExamples/LoafExamples/Examples.swift
+++ b/LoafExamples/LoafExamples/Examples.swift
@@ -12,7 +12,7 @@ import Loaf
 class Examples: UITableViewController {
     
     private enum Example: String, CaseIterable {
-        case success  = "An action was successfully completed"
+        case success  = "An action was successfully completed - An action was successfully completed"
         case error    = "An error has occured"
         case warning  = "A warning has occured"
         case info     = "This is some information"
@@ -28,11 +28,12 @@ class Examples: UITableViewController {
         case custom1  = "This will showcase using custom colors and font"
         case custom2  = "This will showcase using right icon alignment"
         case custom3  = "This will showcase using no icon and 80% screen size width"
+        case custom4  = "This will showcase custom spacing, content insets, and icon size"
 		
         static let grouped: [[Example]] = [[.success, .error, .warning, .info],
                                            [.bottom, .top],
                                            [.vertical, .left, .right, .mix],
-                                           [.custom1, .custom2, .custom3]]
+                                           [.custom1, .custom2, .custom3, custom4]]
     }
     
     private var isDarkMode = false
@@ -112,6 +113,10 @@ class Examples: UITableViewController {
             Loaf(example.rawValue, state: .custom(.init(backgroundColor: .purple, iconAlignment: .right)), sender: self).show()
         case .custom3:
             Loaf(example.rawValue, state: .custom(.init(backgroundColor: .black, icon: nil, textAlignment: .center, width: .screenPercentage(0.8))), sender: self).show()
+        case .custom4:
+            let redColor = UIColor(red: 204.0/255, green: 51.0/255, blue: 51.0/255, alpha: 1)
+            let lightRedColor = UIColor(red: 255.0/255, green: 238.0/255, blue: 238.0/255, alpha: 1)
+            Loaf(example.rawValue, state: .custom(.init(backgroundColor: lightRedColor, textColor: redColor, tintColor: redColor, icon: UIImage(named: "moon"), iconSize: CGSize(width: 16, height: 16), textAlignment: .left, iconAlignment: .right, width: .screenPercentage(0.8), spaceBetweenTextAndIcon: 16, contentInsets: UIEdgeInsets(top: 8, left: 16, bottom: 8, right: 16))), sender: self).show()
         }
         
         tableView.deselectRow(at: indexPath, animated: true)

--- a/Sources/Loaf/Extensions.swift
+++ b/Sources/Loaf/Extensions.swift
@@ -20,9 +20,22 @@ extension UIViewController {
 }
 
 extension String {
-    func heightWithConstrainedWidth(width: CGFloat, font: UIFont) -> CGFloat {
+    func heightWithConstrainedWidth(width: CGFloat, font: UIFont, lineSpacing: CGFloat?) -> CGFloat {
+        var attributes: [NSAttributedString.Key : Any] = [:]
+        if let lineSpacing = lineSpacing {
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.lineSpacing = lineSpacing
+            attributes[NSAttributedString.Key.paragraphStyle] = paragraphStyle
+        }
+        attributes[NSAttributedString.Key.font] = font
+
         let constraintRect = CGSize(width: width, height: .greatestFiniteMagnitude)
-        let boundingBox = self.boundingRect(with: constraintRect, options: [.usesLineFragmentOrigin, .usesFontLeading], attributes: [NSAttributedString.Key.font: font], context: nil)
+        let boundingBox = self.boundingRect(
+            with: constraintRect,
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: attributes,
+            context: nil
+        )
         return boundingBox.height
     }
 }
@@ -44,5 +57,32 @@ extension UIColor {
             (a, r, g, b) = (255, 0, 0, 0)
         }
         self.init(red: CGFloat(r) / 255, green: CGFloat(g) / 255, blue: CGFloat(b) / 255, alpha: CGFloat(a) / 255)
+    }
+}
+
+extension UILabel {
+    func setLineSpacing(lineSpacing: CGFloat) {
+        // Create a mutable attributed string with the label's text
+        guard let labelText = text else { return }
+        let attributedString = NSMutableAttributedString(string: labelText)
+
+        // Create an instance of NSMutableParagraphStyle to configure the paragraph style
+        let paragraphStyle = NSMutableParagraphStyle()
+
+        // Set the desired line spacing value
+        paragraphStyle.lineSpacing = lineSpacing
+
+        // Preserve existing label properties
+        let labelFont = font ?? UIFont.systemFont(ofSize: 17.0) // Default font size
+        let labelColor = textColor ?? UIColor.black
+        let labelAlignment = textAlignment
+
+        // Apply the label properties to the attributed string
+        attributedString.addAttribute(.font, value: labelFont, range: NSMakeRange(0, attributedString.length))
+        attributedString.addAttribute(.foregroundColor, value: labelColor, range: NSMakeRange(0, attributedString.length))
+        attributedString.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attributedString.length))
+
+        // Set the attributed string and preserved properties on the label
+        self.attributedText = attributedString
     }
 }

--- a/Sources/Loaf/Loaf.swift
+++ b/Sources/Loaf/Loaf.swift
@@ -46,7 +46,10 @@ final public class Loaf {
         
         /// The icon on the loaf
         let icon: UIImage?
-        
+
+        /// The size of the icon
+        let iconSize: CGSize?
+
         /// The alignment of the text within the Loaf
         let textAlignment: NSTextAlignment
         
@@ -55,6 +58,12 @@ final public class Loaf {
 		
         /// The width of the loaf
         let width: Width
+
+        /// When an icon is present, this is the separation between the icon and text.
+        let spaceBetweenTextAndIcon: CGFloat?
+
+        /// Insets of the text plus the icon if provided.
+        let contentInsets: UIEdgeInsets?
 		
         public init(
             backgroundColor: UIColor,
@@ -62,17 +71,23 @@ final public class Loaf {
             tintColor: UIColor = .white,
             font: UIFont = .systemFont(ofSize: 14, weight: .medium),
             icon: UIImage? = Icon.info,
+            iconSize: CGSize? = nil,
             textAlignment: NSTextAlignment = .left,
             iconAlignment: IconAlignment = .left,
-            width: Width = .fixed(280)) {
+            width: Width = .fixed(280),
+            spaceBetweenTextAndIcon: CGFloat? = nil,
+            contentInsets: UIEdgeInsets? = nil) {
             self.backgroundColor = backgroundColor
             self.textColor = textColor
             self.tintColor = tintColor
             self.font = font
             self.icon = icon
+            self.iconSize = iconSize
             self.textAlignment = textAlignment
             self.iconAlignment = iconAlignment
             self.width = width
+            self.spaceBetweenTextAndIcon = spaceBetweenTextAndIcon
+            self.contentInsets = contentInsets
         }
     }
     
@@ -225,6 +240,11 @@ protocol LoafDelegate: AnyObject {
 }
 
 final class LoafViewController: UIViewController {
+
+    static let defaultIconSize = CGSize(width: 28, height: 28)
+    static let defaultSpaceBetweenTextAndIcon: CGFloat = 10.0
+    static let defaultContentInsets = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)
+
     var loaf: Loaf
     
     let label = UILabel()
@@ -239,22 +259,32 @@ final class LoafViewController: UIViewController {
         self.transDelegate = Manager(loaf: toast, size: .zero)
         super.init(nibName: nil, bundle: nil)
 		
-        var width: CGFloat?
+        var loafWidth: CGFloat = 280
         if case let Loaf.State.custom(style) = loaf.state {
             self.font = style.font
             self.textAlignment = style.textAlignment
 			
             switch style.width {
             case .fixed(let value):
-                width = value
+                loafWidth = value
             case .screenPercentage(let percentage):
                 guard 0...1 ~= percentage else { return }
-                width = UIScreen.main.bounds.width * percentage
+                loafWidth = UIScreen.main.bounds.width * percentage
             }
         }
-        
-        let height = max(toast.message.heightWithConstrainedWidth(width: 240, font: font) + 12, 40)
-        preferredContentSize = CGSize(width: width ?? 280, height: height)
+
+        var usesIcon = true
+        if case let Loaf.State.custom(style) = loaf.state {
+            usesIcon = style.icon != nil
+        }
+
+        var textWidth: CGFloat = loafWidth - contentInsets.left - contentInsets.right
+        if usesIcon {
+            textWidth = textWidth - iconSize.width - spaceBetweenTextAndIcon
+        }
+
+        let textHeight = max(toast.message.heightWithConstrainedWidth(width: textWidth, font: font), 40)
+        preferredContentSize = CGSize(width: loafWidth, height: textHeight + contentInsets.top + contentInsets.bottom + 1)
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -320,7 +350,7 @@ final class LoafViewController: UIViewController {
             self?.loaf.completionHandler?(.tapped)
         }
     }
-    
+
     private func constrainWithIconAlignment(_ alignment: Loaf.Style.IconAlignment, showsIcon: Bool = true) {
         view.addSubview(label)
         
@@ -330,37 +360,58 @@ final class LoafViewController: UIViewController {
             switch alignment {
             case .left:
                 NSLayoutConstraint.activate([
-                    imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
+                    imageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: contentInsets.left),
                     imageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-                    imageView.heightAnchor.constraint(equalToConstant: 28),
-                    imageView.widthAnchor.constraint(equalToConstant: 28),
+                    imageView.heightAnchor.constraint(equalToConstant: iconSize.height),
+                    imageView.widthAnchor.constraint(equalToConstant: iconSize.width),
                     
-                    label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 10),
-                    label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -4),
-                    label.topAnchor.constraint(equalTo: view.topAnchor),
-                    label.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+                    label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: spaceBetweenTextAndIcon),
+                    label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -contentInsets.right),
+                    label.topAnchor.constraint(equalTo: view.topAnchor, constant: contentInsets.top),
+                    label.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -contentInsets.bottom)
                 ])
             case .right:
                 NSLayoutConstraint.activate([
-                    imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10),
+                    imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -contentInsets.right),
                     imageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-                    imageView.heightAnchor.constraint(equalToConstant: 28),
-                    imageView.widthAnchor.constraint(equalToConstant: 28),
+                    imageView.heightAnchor.constraint(equalToConstant: iconSize.height),
+                    imageView.widthAnchor.constraint(equalToConstant: iconSize.width),
                     
-                    label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
-                    label.trailingAnchor.constraint(equalTo: imageView.leadingAnchor, constant: -4),
-                    label.topAnchor.constraint(equalTo: view.topAnchor),
-                    label.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+                    label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: contentInsets.left),
+                    label.trailingAnchor.constraint(equalTo: imageView.leadingAnchor, constant: -spaceBetweenTextAndIcon),
+                    label.topAnchor.constraint(equalTo: view.topAnchor, constant: contentInsets.top),
+                    label.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -contentInsets.bottom)
                 ])
             }
         } else {
             NSLayoutConstraint.activate([
-                label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 10),
-                label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -10),
-                label.topAnchor.constraint(equalTo: view.topAnchor),
-                label.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+                label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: contentInsets.left),
+                label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -contentInsets.right),
+                label.topAnchor.constraint(equalTo: view.topAnchor, constant: contentInsets.top),
+                label.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -contentInsets.bottom)
             ])
         }
+    }
+
+    private var iconSize: CGSize {
+        if case let .custom(style) = loaf.state {
+            return style.iconSize ?? Self.defaultIconSize
+        }
+        return Self.defaultIconSize
+    }
+
+    private var spaceBetweenTextAndIcon: CGFloat {
+        if case let .custom(style) = loaf.state {
+            return style.spaceBetweenTextAndIcon ?? Self.defaultSpaceBetweenTextAndIcon
+        }
+        return Self.defaultSpaceBetweenTextAndIcon
+    }
+
+    private var contentInsets: UIEdgeInsets {
+        if case let .custom(style) = loaf.state {
+            return style.contentInsets ?? Self.defaultContentInsets
+        }
+        return Self.defaultContentInsets
     }
 }
 

--- a/Sources/Loaf/Loaf.swift
+++ b/Sources/Loaf/Loaf.swift
@@ -64,6 +64,9 @@ final public class Loaf {
 
         /// Insets of the text plus the icon if provided.
         let contentInsets: UIEdgeInsets?
+
+        /// Space between lines. Optional. If not provided, it will use the default operating system value.
+        let lineSpacing: CGFloat?
 		
         public init(
             backgroundColor: UIColor,
@@ -76,7 +79,8 @@ final public class Loaf {
             iconAlignment: IconAlignment = .left,
             width: Width = .fixed(280),
             spaceBetweenTextAndIcon: CGFloat? = nil,
-            contentInsets: UIEdgeInsets? = nil) {
+            contentInsets: UIEdgeInsets? = nil,
+            lineSpacing: CGFloat? = nil) {
             self.backgroundColor = backgroundColor
             self.textColor = textColor
             self.tintColor = tintColor
@@ -88,6 +92,7 @@ final public class Loaf {
             self.width = width
             self.spaceBetweenTextAndIcon = spaceBetweenTextAndIcon
             self.contentInsets = contentInsets
+            self.lineSpacing = lineSpacing
         }
     }
     
@@ -274,8 +279,10 @@ final class LoafViewController: UIViewController {
         }
 
         var usesIcon = true
+        var lineSpacing: CGFloat?
         if case let Loaf.State.custom(style) = loaf.state {
             usesIcon = style.icon != nil
+            lineSpacing = style.lineSpacing
         }
 
         var textWidth: CGFloat = loafWidth - contentInsets.left - contentInsets.right
@@ -283,7 +290,10 @@ final class LoafViewController: UIViewController {
             textWidth = textWidth - iconSize.width - spaceBetweenTextAndIcon
         }
 
-        let textHeight = max(toast.message.heightWithConstrainedWidth(width: textWidth, font: font), 40)
+        let textHeight = max(
+            toast.message.heightWithConstrainedWidth(width: textWidth, font: font, lineSpacing: lineSpacing),
+            40
+        )
         preferredContentSize = CGSize(width: loafWidth, height: textHeight + contentInsets.top + contentInsets.bottom + 1)
     }
     
@@ -331,6 +341,9 @@ final class LoafViewController: UIViewController {
             label.textColor = style.textColor
             label.font = style.font
             constrainWithIconAlignment(style.iconAlignment, showsIcon: imageView.image != nil)
+            if let lineSpacing = style.lineSpacing {
+                label.setLineSpacing(lineSpacing: lineSpacing)
+            }
         }
         
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
@@ -430,4 +443,3 @@ private struct Queue<T> {
         }
     }
 }
-


### PR DESCRIPTION
This PR adds more customisation options (that I needed for my project):
- Icon size
- Content insets
- Separation between icon and text

<img width="516" alt="Screenshot 2023-03-05 at 16 14 35" src="https://user-images.githubusercontent.com/738681/222972516-60a664fc-0623-4394-be77-ac550f9eda12.png">
